### PR TITLE
Update to the oraclizeAPI modifier to only update the connector address in storage if it has changed.

### DIFF
--- a/oraclizeAPI_0.4.sol
+++ b/oraclizeAPI_0.4.sol
@@ -69,8 +69,12 @@ contract usingOraclize {
 
     OraclizeI oraclize;
     modifier oraclizeAPI {
-        if((address(OAR)==0)||(getCodeSize(address(OAR))==0)) oraclize_setNetwork(networkID_auto);
-        oraclize = OraclizeI(OAR.getAddress());
+        if((address(OAR)==0)||(getCodeSize(address(OAR))==0))
+            oraclize_setNetwork(networkID_auto);
+
+        if(address(oraclize) != OAR.getAddress())
+            oraclize = OraclizeI(OAR.getAddress());
+
         _;
     }
     modifier coupon(string code){


### PR DESCRIPTION
Current implementation writes the connector address to storage for every query.

This change only does so if the address has changed and therefore saves a storage write on each query.