### PR TITLE
Add fix for matchBytes32Prefix

### DIFF
--- a/oraclizeAPI_0.4.sol
+++ b/oraclizeAPI_0.4.sol
@@ -874,7 +874,7 @@ contract usingOraclize {
     function matchBytes32Prefix(bytes32 content, bytes prefix, uint n_random_bytes) internal returns (bool){
         bool match_ = true;
         
-        for (var i=0; i< n_random,_bytes; i++) {
+        for (var i=0; i< n_random_bytes; i++) {
             if (content[i] != prefix[i]) match_ = false;
         }
 
@@ -893,7 +893,7 @@ contract usingOraclize {
         copyBytes(proof, ledgerProofLength+(32+8+1+32), sig1.length, sig1, 0);
 
         // Step 3: we assume sig1 is valid (it will be verified during step 5) and we verify if 'result' is the prefix of sha256(sig1)
-        if (!matchBytes32Prefix(sha256(sig1), result, uint(proof[ledgerProofLength+32+8])) return false;
+        if (!matchBytes32Prefix(sha256(sig1), result, uint(proof[ledgerProofLength+32+8]))) return false;
 
         // Step 4: commitment match verification, sha3(delay, nbytes, unonce, sessionKeyHash) == commitment in storage.
         // This is to verify that the computed args match with the ones specified in the query.

--- a/oraclizeAPI_0.4.sol
+++ b/oraclizeAPI_0.4.sol
@@ -1020,4 +1020,4 @@ contract usingOraclize {
     }
 
 }
-// <ORACLIZE_API>
+// </ORACLIZE_API>

--- a/oraclizeAPI_0.4.sol
+++ b/oraclizeAPI_0.4.sol
@@ -871,13 +871,10 @@ contract usingOraclize {
         return 0;
     }
 
-    function matchBytes32Prefix(bytes32 content, bytes prefix, bytes proof) internal returns (bool){
+    function matchBytes32Prefix(bytes32 content, bytes prefix, uint n_random_bytes) internal returns (bool){
         bool match_ = true;
         
-        bytes memory nbytes = new bytes(1);
-        copyBytes(proof, 3+65+(uint(proof[3+65+1])+2)+32 + 32 + 8,1, nbytes, 0);
-
-        for (var i=0; i< uint(nbytes[0]); i++) {
+        for (var i=0; i< n_random,_bytes; i++) {
             if (content[i] != prefix[i]) match_ = false;
         }
 
@@ -896,7 +893,7 @@ contract usingOraclize {
         copyBytes(proof, ledgerProofLength+(32+8+1+32), sig1.length, sig1, 0);
 
         // Step 3: we assume sig1 is valid (it will be verified during step 5) and we verify if 'result' is the prefix of sha256(sig1)
-        if (!matchBytes32Prefix(sha256(sig1), result, proof)) return false;
+        if (!matchBytes32Prefix(sha256(sig1), result, uint(proof[ledgerProofLength+32+8])) return false;
 
         // Step 4: commitment match verification, sha3(delay, nbytes, unonce, sessionKeyHash) == commitment in storage.
         // This is to verify that the computed args match with the ones specified in the query.

--- a/oraclizeAPI_0.5.sol
+++ b/oraclizeAPI_0.5.sol
@@ -868,10 +868,13 @@ contract usingOraclize {
         return 0;
     }
 
-    function matchBytes32Prefix(bytes32 content, bytes prefix) internal pure returns (bool){
+    function matchBytes32Prefix(bytes32 content, bytes prefix, bytes proof) internal pure returns (bool){
         bool match_ = true;
+        
+        bytes memory nbytes = new bytes(1);
+        copyBytes(proof, 3+65+(uint(proof[3+65+1])+2)+32 + 32 + 8,1, nbytes, 0);
 
-        for (uint256 i=0; i<prefix.length; i++){
+        for (uint256 i=0; i< uint(nbytes[0]); i++) {
             if (content[i] != prefix[i]) match_ = false;
         }
 
@@ -879,24 +882,18 @@ contract usingOraclize {
     }
 
     function oraclize_randomDS_proofVerify__main(bytes proof, bytes32 queryId, bytes result, string context_name) internal returns (bool){
-        bool checkok;
-
 
         // Step 2: the unique keyhash has to match with the sha256 of (context name + queryId)
         uint ledgerProofLength = 3+65+(uint(proof[3+65+1])+2)+32;
         bytes memory keyhash = new bytes(32);
         copyBytes(proof, ledgerProofLength, 32, keyhash, 0);
-        checkok = (keccak256(keyhash) == keccak256(sha256(context_name, queryId)));
-        if (checkok == false) return false;
+        if (!(keccak256(keyhash) == keccak256(sha256(context_name, queryId)))) return false;
 
         bytes memory sig1 = new bytes(uint(proof[ledgerProofLength+(32+8+1+32)+1])+2);
         copyBytes(proof, ledgerProofLength+(32+8+1+32), sig1.length, sig1, 0);
 
-
         // Step 3: we assume sig1 is valid (it will be verified during step 5) and we verify if 'result' is the prefix of sha256(sig1)
-        checkok = matchBytes32Prefix(sha256(sig1), result);
-        if (checkok == false) return false;
-
+        if (!matchBytes32Prefix(sha256(sig1), result, proof)) return false;
 
         // Step 4: commitment match verification, keccak256(delay, nbytes, unonce, sessionKeyHash) == commitment in storage.
         // This is to verify that the computed args match with the ones specified in the query.
@@ -916,8 +913,7 @@ contract usingOraclize {
         // Step 5: validity verification for sig1 (keyhash and args signed with the sessionKey)
         bytes memory tosign1 = new bytes(32+8+1+32);
         copyBytes(proof, ledgerProofLength, 32+8+1+32, tosign1, 0);
-        checkok = verifySig(sha256(tosign1), sig1, sessionPubkey);
-        if (checkok == false) return false;
+        if (!verifySig(sha256(tosign1), sig1, sessionPubkey)) return false;
 
         // verify if sessionPubkeyHash was verified already, if not.. let's do it!
         if (oraclize_randomDS_sessionKeysHashVerified[sessionPubkeyHash] == false){
@@ -926,7 +922,6 @@ contract usingOraclize {
 
         return oraclize_randomDS_sessionKeysHashVerified[sessionPubkeyHash];
     }
-
 
     // the following function has been written by Alex Beregszaszi (@axic), use it under the terms of the MIT license
     function copyBytes(bytes from, uint fromOffset, uint length, bytes to, uint toOffset) internal pure returns (bytes) {

--- a/oraclizeAPI_0.5.sol
+++ b/oraclizeAPI_0.5.sol
@@ -868,13 +868,11 @@ contract usingOraclize {
         return 0;
     }
 
-    function matchBytes32Prefix(bytes32 content, bytes prefix, bytes proof) internal pure returns (bool){
+    function matchBytes32Prefix(bytes32 content, bytes prefix, uint n_random_bytes) internal pure returns (bool){
         bool match_ = true;
         
-        bytes memory nbytes = new bytes(1);
-        copyBytes(proof, 3+65+(uint(proof[3+65+1])+2)+32 + 32 + 8,1, nbytes, 0);
 
-        for (uint256 i=0; i< uint(nbytes[0]); i++) {
+        for (uint256 i=0; i< n_random_bytes; i++) {
             if (content[i] != prefix[i]) match_ = false;
         }
 
@@ -893,7 +891,7 @@ contract usingOraclize {
         copyBytes(proof, ledgerProofLength+(32+8+1+32), sig1.length, sig1, 0);
 
         // Step 3: we assume sig1 is valid (it will be verified during step 5) and we verify if 'result' is the prefix of sha256(sig1)
-        if (!matchBytes32Prefix(sha256(sig1), result, proof)) return false;
+        if (!matchBytes32Prefix(sha256(sig1), result, uint(proof[ledgerProofLength+32+8]))) return false;
 
         // Step 4: commitment match verification, keccak256(delay, nbytes, unonce, sessionKeyHash) == commitment in storage.
         // This is to verify that the computed args match with the ones specified in the query.


### PR DESCRIPTION
This PR fixes a mistake in matchBytes32Prefix, in both the new API version and the old one.  
matchBytes32Prefix verify if the string sends by Oraclize as the result parameter of the callback is the SHA256 of the signature. Unfortunately, the comparison between the two byte arrays takes as a parameter the lenght of the string result, which is controlled by Oraclize. Therefore, it could be possible for the proof verification to pass even in the case Oraclize is returning an empty string in the callback. 

If you see a more efficient way to do this, please suggest. Unfortunately, I was limited by the stack depth and I add to change the oraclize_randomDS_proofVerify__main to reduce the number of variables.
