### PR TITLE
Revert "Update pragma solidity"

### DIFF
--- a/lib-experimental/oraclizeAPI_lib.sol
+++ b/lib-experimental/oraclizeAPI_lib.sol
@@ -28,7 +28,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 */
 
-pragma solidity 0.4.19; //pragma experimental "v0.5.0";
+pragma solidity ^0.4.19; //pragma experimental "v0.5.0";
 
 contract OraclizeI {
     address public cbAddress;

--- a/oraclizeAPI_0.4.sol
+++ b/oraclizeAPI_0.4.sol
@@ -28,7 +28,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 */
 
-pragma solidity >=0.4.0 <=0.4.19; // Incompatible compiler version... please select one stated within pragma solidity
+pragma solidity ^0.4.0;//please import oraclizeAPI_pre0.4.sol when solidity < 0.4.0
 
 contract OraclizeI {
     address public cbAddress;

--- a/oraclizeAPI_0.5.sol
+++ b/oraclizeAPI_0.5.sol
@@ -29,7 +29,7 @@ THE SOFTWARE.
 */
 
 // This api is currently targeted at 0.4.18, please import oraclizeAPI_pre0.4.sol or oraclizeAPI_0.4 where necessary
-pragma solidity >=0.4.18 <=0.4.19; // Incompatible compiler version... please select one stated within pragma solidity
+pragma solidity ^0.4.18;
 
 contract OraclizeI {
     address public cbAddress;


### PR DESCRIPTION
Reverts oraclize/ethereum-api#48

Reverting change, as after tests, it appears the issue is specific to only Oraclize's remix fork.