### PR TITLE
feat(ethereum-api): adds package.json for npm import compatibility

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "oraclize-eth-api",
   "version": "0.5.0",
-  "description": "Thanks to this [Ethereum API helpers](https://github.com/oraclize/ethereum-api) using Oraclize in your Solidity/Serpent code is very easy.",
+  "description": "The Oraclize API - Importable in your smart-contract in order to start leveraging the Oraclize service quickly and easily!.",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/oraclize/ethereum-api.git"

--- a/package.json
+++ b/package.json
@@ -1,0 +1,14 @@
+{
+  "name": "oraclize-eth-api",
+  "version": "0.5.0",
+  "description": "Thanks to this [Ethereum API helpers](https://github.com/oraclize/ethereum-api) using Oraclize in your Solidity/Serpent code is very easy.",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/oraclize/ethereum-api.git"
+  },
+  "license": "MIT",
+  "bugs": {
+    "url": "https://github.com/oraclize/ethereum-api/issues"
+  },
+  "homepage": "http://www.oraclize.it"
+}


### PR DESCRIPTION
...per title, and PRd as explained in __[this issue here](https://github.com/oraclize/priv-intermediate-issue-tracker/issues/227)__.

Also tweaked the wording in the `package.json`'s description since the first version was likely autogenerated from the `README.md` and so made little sense in this context.