### PR TITLE
fix/natspec doxygen bug

### DIFF
--- a/oraclizeAPI_0.4.25.sol
+++ b/oraclizeAPI_0.4.25.sol
@@ -1138,7 +1138,7 @@ contract usingOraclize {
         return oraclize_randomDS_sessionKeysHashVerified[sessionPubkeyHash];
     }
 
-    // the following function has been written by Alex Beregszaszi (@axic), use it under the terms of the MIT license
+    // the following function has been written by Alex Beregszaszi, use it under the terms of the MIT license
     function copyBytes(bytes from, uint fromOffset, uint length, bytes to, uint toOffset) internal pure returns (bytes) {
         uint minLength = length + toOffset;
 
@@ -1161,7 +1161,7 @@ contract usingOraclize {
         return to;
     }
 
-    // the following function has been written by Alex Beregszaszi (@axic), use it under the terms of the MIT license
+    // the following function has been written by Alex Beregszaszi, use it under the terms of the MIT license
     // Duplicate Solidity's ecrecover, but catching the CALL return value
     function safer_ecrecover(bytes32 hash, uint8 v, bytes32 r, bytes32 s) internal returns (bool, address) {
         // We do our own memory management here. Solidity uses memory offset
@@ -1190,7 +1190,7 @@ contract usingOraclize {
         return (ret, addr);
     }
 
-    // the following function has been written by Alex Beregszaszi (@axic), use it under the terms of the MIT license
+    // the following function has been written by Alex Beregszaszi, use it under the terms of the MIT license
     function ecrecovery(bytes32 hash, bytes sig) internal returns (bool, address) {
         bytes32 r;
         bytes32 s;

--- a/oraclizeAPI_0.4.sol
+++ b/oraclizeAPI_0.4.sol
@@ -1138,7 +1138,7 @@ contract usingOraclize {
     }
 
 
-    // the following function has been written by Alex Beregszaszi (@axic), use it under the terms of the MIT license
+    // the following function has been written by Alex Beregszaszi, use it under the terms of the MIT license
     function copyBytes(bytes from, uint fromOffset, uint length, bytes to, uint toOffset) internal returns (bytes) {
         uint minLength = length + toOffset;
 
@@ -1163,7 +1163,7 @@ contract usingOraclize {
         return to;
     }
 
-    // the following function has been written by Alex Beregszaszi (@axic), use it under the terms of the MIT license
+    // the following function has been written by Alex Beregszaszi, use it under the terms of the MIT license
     // Duplicate Solidity's ecrecover, but catching the CALL return value
     function safer_ecrecover(bytes32 hash, uint8 v, bytes32 r, bytes32 s) internal returns (bool, address) {
         // We do our own memory management here. Solidity uses memory offset
@@ -1192,7 +1192,7 @@ contract usingOraclize {
         return (ret, addr);
     }
 
-    // the following function has been written by Alex Beregszaszi (@axic), use it under the terms of the MIT license
+    // the following function has been written by Alex Beregszaszi, use it under the terms of the MIT license
     function ecrecovery(bytes32 hash, bytes sig) internal returns (bool, address) {
         bytes32 r;
         bytes32 s;

--- a/oraclizeAPI_0.5.sol
+++ b/oraclizeAPI_0.5.sol
@@ -1244,7 +1244,7 @@ contract usingOraclize {
         return oraclize_randomDS_sessionKeysHashVerified[sessionPubkeyHash];
     }
     /*
-     The following function has been written by Alex Beregszaszi (@axic), use it under the terms of the MIT license
+     The following function has been written by Alex Beregszaszi, use it under the terms of the MIT license
     */
     function copyBytes(bytes memory _from, uint _fromOffset, uint _length, bytes memory _to, uint _toOffset) internal pure returns (bytes memory _copiedBytes) {
         uint minLength = _length + _toOffset;
@@ -1262,7 +1262,7 @@ contract usingOraclize {
         return _to;
     }
     /*
-     The following function has been written by Alex Beregszaszi (@axic), use it under the terms of the MIT license
+     The following function has been written by Alex Beregszaszi, use it under the terms of the MIT license
      Duplicate Solidity's ecrecover, but catching the CALL return value
     */
     function safer_ecrecover(bytes32 _hash, uint8 _v, bytes32 _r, bytes32 _s) internal returns (bool _success, address _recoveredAddress) {
@@ -1288,7 +1288,7 @@ contract usingOraclize {
         return (ret, addr);
     }
     /*
-     The following function has been written by Alex Beregszaszi (@axic), use it under the terms of the MIT license
+     The following function has been written by Alex Beregszaszi, use it under the terms of the MIT license
     */
     function ecrecovery(bytes32 _hash, bytes memory _sig) internal returns (bool _success, address _recoveredAddress) {
         bytes32 r;


### PR DESCRIPTION
...that can cause compiler issues in some rare cases. 

It's the second time it's happened and both times were difficult to track down. So rather than waste time trying, this PR just removes the offending `@` tag. The credit to Alex for his `ecrecover` remains, just sans twitter handle.